### PR TITLE
minor update to clarify for novices

### DIFF
--- a/copy_to_pythonanywhere.md
+++ b/copy_to_pythonanywhere.md
@@ -5,7 +5,7 @@
 * 
 Copy the HTTPS clone url for the fork (it should resemble https://github.com/[your_username]/hello-world-bot.git)
 * 
-Go back to the PythonAnywhere bash console and run ``git clone clone url``
+Go back to the PythonAnywhere bash console and run ``git clone {clone url}`` where ``{clone url}`` is the web address you just copied.
 
 ##What did we just do?
 "Cloning" a GitHub repo means taking some code that exists on GitHub and putting it somewhere that you can use and edit it. Here, we took your forked copy of the hello-world-bot template and put it on your PythonAnywhere server.


### PR DESCRIPTION
Tries to make it clearer that `{clone url}` isn't the _literal_ string "clone url". Maybe I'm the only one who might have been confused by that at some point. :-)
